### PR TITLE
nimbleLists in RCfuns

### DIFF
--- a/UserManual/chapter_DataStructures.Rnw
+++ b/UserManual/chapter_DataStructures.Rnw
@@ -272,21 +272,20 @@ nimbleList definitions can be created either in R's global environment or in \cd
 
 nimbleLists can also be passed as arguments to run code of nimbleFunctions and returned from nimbleFunctions.  To use a nimbleList as a run function argument, the name of the nimbleList definition should be provided as the argument type, with a set of parentheses following.  To return a nimbleList from the run code of a nimbleFunction, the \cd{returnType} of that function should be the name of the nimbleList definition, again using a following set of parentheses.
 
-Below, we demonstrate a function that takes the \cd{exampleNimList} as an argument, modifies its \cd{Y} element, and returns the nimbleList.  We note that nimbleFunctions that take nimbleLists as run arguments must have setup code.  For functions that need no setup code, setting \cd{setup = TRUE} will allow these functions to work correctly.
+Below, we demonstrate a function that takes the \cd{exampleNimList} as an argument, modifies its \cd{Y} element, and returns the nimbleList.
 
 <<exampleNimListFunction>>=
 mynf <- nimbleFunction(
-  setup = TRUE,
   run = function(vals = exampleNimListDef()){
     onesMatrix <- matrix(value = 1, nrow = 2, ncol = 2)
     vals$Y  <- onesMatrix
     returnType(exampleNimListDef())
     return(vals)
   })
-Rnf <- mynf()
+ 
+## pass exampleNimList as argument to mynf
+mynf(exampleNimList)
 
-## pass exampleNimList as argument to run function
-Rnf$run(exampleNimList)
 @
 
 nimbleList arguments to run functions are passed by reference -- this means that if an element of a nimbleList argument is modified within a function, that element will remain modified when the function has finished running.  To see this, we can inspect the value of the \cd{Y} element of the \cd{exampleNimList} object and see that it has been modified.

--- a/UserManual/chapter_RCfunctions.Rnw
+++ b/UserManual/chapter_RCfunctions.Rnw
@@ -361,11 +361,13 @@ dimensions are supported for double, integer, and logical.  Only
 vectors (one dimension) are supported for character.  Unlike R, NIMBLE supports true
 scalars, which have 0 dimensions.
 
-% A nimbleList data structure can contain arbitrary other NIMBLE objects,
-% including other nimbleLists.  Like other NIMBLE types, nimbleLists are
-% strongly typed: each nimbleList is created from a configuration that
-% declares what types of objects it will hold.  nimbleLists are covered
-% in chapter (\ref{XYZ}).
+
+\subsection{\cd{nimbleList} data structures}
+\label{sec:nimbleList-RCFuns}
+
+A \cd{nimbleList} is a data structure that can contain arbitrary other NIMBLE objects, including other \cd{nimbleList}s.
+Like other NIMBLE types, nimbleLists are strongly typed: each \cd{nimbleList} is created from a configuration that
+declares what types of objects it will hold.  \cd{nimbleList}s are covered in Chapter \ref{sec:nimbleLists}.
 
 \subsection{How numeric types work}
 \label{sec:how-types-work}

--- a/UserManual/chapter_WritingNimbleFunctions.Rnw
+++ b/UserManual/chapter_WritingNimbleFunctions.Rnw
@@ -128,7 +128,7 @@ Some of the useful tools and objects to create in setup functions include:
   \cd{getNodeNames}, \\\cd{getDependencies}, and other methods of a model,
   described in Sections \ref{sec:accessing-variables}-\ref{sec:nodeInfo}.
 \item[modelValues objects] These are discussed in Sections \ref{sec:modelValues-struct} and \ref{sec:access-model-modelv}.
-\item[nimbleList objects]  New instances of \cd{nimbleList}s can then
+\item[nimbleList objects]  New instances of \cd{nimbleList}s can
   be created from a nimbleList definition in either setup or run code. See Section \ref{sec:nimbleLists} for more information.
   % Comment: It is actually sketchy that we allow a nimbleList
   % definition to be created in setup code, because it would  have to
@@ -198,7 +198,7 @@ anywhere in the setup code.
 \section{Writing run code}
 \label{sec:nimble-lang-comp}
 
-In Chapter \ref{cha:RCfunctions} we described the functionality of the NIMBLE language that could be used in run code without setup code (typically in cases where no models, modelValues, or nimbleLists are needed).   Next we explain the additional features that allow use of models, modelValues, and nimbleLists in the run code. 
+In Chapter \ref{cha:RCfunctions} we described the functionality of the NIMBLE language that could be used in run code without setup code (typically in cases where no models or modelValues are needed).   Next we explain the additional features that allow use of models and modelValues in the run code. 
 
 \subsection{Driving models: \cd{calculate}, \cd{calculateDiff},
   \cd{simulate}, \cd{getLogProb}}


### PR DESCRIPTION
This commit adds references to nimbleLists from RCfunctions chapter, and removes stipulation that setup code must exist for nimbleLists to be used.